### PR TITLE
Separate functionality of deploying and rolling back

### DIFF
--- a/app_deployer/args.py
+++ b/app_deployer/args.py
@@ -1,27 +1,22 @@
 # Import built-in packages
 import sys
-import logging
 import argparse
 
-# Import CPC packages
-from app_deployer import config
 
-
-# Parse command-line arguments
-def parse_args(argv):
+def parse_args(argv, entry_point):
     """
     Parse the command line args
 
-    Note that the argv argument will be parsed instead of sys.argv because
-    the test suite will need to execute the main() function, and will
-    therefore need to pass the given arguments to that function, as opposed
-    to the main() function getting them from sys.argv.
+    Note that the argv argument will be parsed instead of sys.argv because the test suite will
+    need to execute the main() function, and will therefore need to pass the given arguments to
+    that function, as opposed to the main() function getting them from sys.argv.
 
     Parameters
     ----------
 
-    - argv - *list of strings* - argument list containing the elements from
-    sys.argv, except the first element (sys.argv[0]) which is the script name
+    - argv - *list of str* - argument list containing the elements from sys.argv, except the
+    first element (sys.argv[0]) which is the script name
+    - entry_point - *str* - name of the entry_point (in setup.py) to parse args for
     """
     # Create an ArgumentParser object
     parser = argparse.ArgumentParser(add_help=False, usage='%(prog)s [options] <app> <host>')
@@ -64,29 +59,3 @@ def parse_args(argv):
     args.log_level = args.log_level.upper()
 
     return args
-
-
-def main(argv=None):
-    # If argv is None, set it to sys.argv
-    if argv is None:
-        argv = sys.argv
-    # Setup logging
-    logging.basicConfig(
-        level=logging.DEBUG,
-        format='[%(asctime)s - %(name)s - %(levelname)s] %(message)s',
-        datefmt='%Y-%m-%d %I:%M:%S%p'
-    )
-    logger = logging.getLogger('app-deployer')
-
-    # --------------------------------------------------------------------------
-    # Parse command-line arguments
-    #
-    args = parse_args(argv[1:])
-    # Set log level
-    logger.setLevel(getattr(logging, args.log_level))
-
-    logger.info("This is the main function.")
-
-
-if __name__ == "__main__":
-    sys.exit(main())

--- a/app_deployer/deploy.py
+++ b/app_deployer/deploy.py
@@ -1,0 +1,27 @@
+# Import built-in packages
+import sys
+import logging
+
+# Import modules from this app
+from .logging import setup_logging
+from .args import parse_args
+
+
+def main(argv=None):
+    # Get entry_point name
+    entry_point = __name__.split('.')[-1]
+    # If argv is None, set it to sys.argv
+    if argv is None:
+        argv = sys.argv
+    # Setup logging
+    logger = setup_logging(entry_point)
+    # Parse command-line arguments
+    args = parse_args(argv[1:], entry_point)
+    # Set log level
+    logger.setLevel(getattr(logging, args.log_level))
+
+    logger.info('This is the {} script...'.format(entry_point))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/app_deployer/logging.py
+++ b/app_deployer/logging.py
@@ -1,0 +1,11 @@
+# Import built-in packages
+import logging
+
+
+def setup_logging(name):
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format='[%(asctime)s - %(name)s - %(levelname)s] %(message)s',
+        datefmt='%Y-%m-%d %I:%M:%S%p'
+    )
+    return logging.getLogger(name)

--- a/app_deployer/rollback.py
+++ b/app_deployer/rollback.py
@@ -1,0 +1,27 @@
+# Import built-in packages
+import sys
+import logging
+
+# Import modules from this app
+from .logging import setup_logging
+from .args import parse_args
+
+
+def main(argv=None):
+    # Get entry_point name
+    entry_point = __name__.split('.')[-1]
+    # If argv is None, set it to sys.argv
+    if argv is None:
+        argv = sys.argv
+    # Setup logging
+    logger = setup_logging(entry_point)
+    # Parse command-line arguments
+    args = parse_args(argv[1:], entry_point)
+    # Set log level
+    logger.setLevel(getattr(logging, args.log_level))
+
+    logger.info('This is the {} script...'.format(entry_point))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            "deploy = app_deployer.__main__:main"
+            'deploy = app_deployer.deploy:main',
+            'rollback = app_deployer.rollback:main',
         ]
     },
 )

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,12 +1,12 @@
 import unittest
 import pytest
 
-from app_deployer import __main__
+from app_deployer import deploy
 
 
 def test_run_deploy_app_without_args(capsys):
     """Ensure a usage message is printed when running `deploy` without args"""
     with pytest.raises(SystemExit):
-        __main__.main()
+        deploy.main()
     out, err = capsys.readouterr()
     assert out and not err

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -1,0 +1,12 @@
+import unittest
+import pytest
+
+from app_deployer import rollback
+
+
+def test_run_deploy_app_without_args(capsys):
+    """Ensure a usage message is printed when running `deploy` without args"""
+    with pytest.raises(SystemExit):
+        rollback.main()
+    out, err = capsys.readouterr()
+    assert out and not err


### PR DESCRIPTION
There are now separate modules for deploying and rolling back code (`deploy.py` and `rollback.py`).

In addition, the arg parsing and logger setup have been moved to separate files so they can be called by both the deploy and rollback scripts.

Finally, there are separate entry_points in `setup.py` for the deploy and rollback scripts.

Closes #11