### PR TITLE
Change from specifying install-file to install-method

### DIFF
--- a/app_deployer/app-inventory.yml
+++ b/app_deployer/app-inventory.yml
@@ -2,7 +2,7 @@
 ---
 - name: app-deployer
   git-url: https://github.com/noaa-nws-cpc/app-deployer.git
-  install-file: ansible/install.yml
+  install-method: ansible
   owner: Mike Charles
   backup-owner:
   account: cpcwebapps

--- a/app_deployer/apps.py
+++ b/app_deployer/apps.py
@@ -61,7 +61,7 @@ class AppInventory:
         for app in self.inventory_dict:
             string += '  {}\n  {}\n\n'.format(app['name'], '-' * len(app['name']))
             string += '    git-url: {}\n'.format(app['git-url'])
-            string += '    install-file: {}\n'.format(app['install-file'])
+            string += '    install-method: {}\n'.format(app['install-method'])
             string += '    owner: {}\n'.format(app['owner'])
             string += '    backup owner: {}\n'.format(app['backup-owner'])
             string += '    account: {}\n'.format(app['account'])

--- a/app_deployer/config.yml
+++ b/app_deployer/config.yml
@@ -8,8 +8,10 @@ app-inventory:
   file:
 # Ansible settings
 ansible:
+  # Path containing Ansible executables
   path:
 # Host settings
 hosts:
+  # Root directory to install apps into
   app-root: $HOME/apps
 ...


### PR DESCRIPTION
App Deployer will make the assumption that a given project will have an `ansible` directory and a `deploy.yml` file for install-method: ansible. So we don't need to know the install file (yet).