### PR TITLE
Rename args to args_parser

### DIFF
--- a/app_deployer/apps.py
+++ b/app_deployer/apps.py
@@ -159,6 +159,7 @@ class AppInventory:
         app_dict = self.get_dict(name)
         # Create an instance of the app
         app = App(name, app_dict['git-url'], app_dict['owner'], app_dict['install-method'],
-                  backup_owner=app_dict['backup-owner'], account=app_dict['account'])
+                  backup_owner=app_dict.get('backup-owner', None),
+                  account=app_dict.get('account', None))
 
         return app

--- a/app_deployer/args.py
+++ b/app_deployer/args.py
@@ -17,6 +17,11 @@ def parse_args(argv, entry_point):
     - argv - *list of str* - argument list containing the elements from sys.argv, except the
     first element (sys.argv[0]) which is the script name
     - entry_point - *str* - name of the entry_point (in setup.py) to parse args for
+
+    Returns
+    -------
+
+    - *ArgumentParser object* - parsed arguments
     """
     # Create an ArgumentParser object
     parser = argparse.ArgumentParser(add_help=False, usage='%(prog)s [options] <app> <host>')

--- a/app_deployer/args_parser.py
+++ b/app_deployer/args_parser.py
@@ -3,6 +3,10 @@ import sys
 import argparse
 
 
+# args variable will be imported by other modules to access the command line args
+args = None
+
+
 def parse_args(argv, entry_point):
     """
     Parse the command line args

--- a/app_deployer/deploy_script.py
+++ b/app_deployer/deploy_script.py
@@ -4,6 +4,7 @@ import logging
 
 # Import third-party packages
 import appdirs
+import coloredlogs
 
 # Import modules from this app
 from app_deployer.logger import setup_logging
@@ -29,6 +30,7 @@ def main(argv=None):
     args = parse_args(argv[1:], entry_point)
     # Set log level
     logger.setLevel(getattr(logging, args.log_level))
+    coloredlogs.install(fmt='%(message)s')
 
     # ----------------------------------------------------------------------------------------------
     # Print out app inventory

--- a/app_deployer/deploy_script.py
+++ b/app_deployer/deploy_script.py
@@ -9,6 +9,7 @@ import coloredlogs
 # Import modules from this app
 from app_deployer.logger import setup_logging
 from app_deployer.args_parser import parse_args
+from app_deployer import args_parser
 from app_deployer.deployment import DeploymentError, Deployment
 
 # Import variables from this app
@@ -27,6 +28,8 @@ def main(argv=None):
     # Setup logging
     logger = setup_logging(entry_point)
     # Parse command-line arguments
+    args_parser.args = parse_args(argv[1:], entry_point)
+    args = args_parser.args
     # Set log level
     logger.setLevel(getattr(logging, args.log_level))
     coloredlogs.install(fmt='%(message)s')
@@ -34,14 +37,14 @@ def main(argv=None):
     # ----------------------------------------------------------------------------------------------
     # Print out app inventory
     #
-    if args_parser.list_apps:
+    if args.list_apps:
         logger.info(app_inventory)
         sys.exit()
 
     # ----------------------------------------------------------------------------------------------
     # Print out hosts inventory
     #
-    if args_parser.list_hosts:
+    if args.list_hosts:
         logger.info(host_inventory)
         sys.exit()
 
@@ -58,25 +61,25 @@ def main(argv=None):
     # Validate the positional args
     #
     # App
-    if not app_inventory.is_app(args_parser.app_name):
+    if not app_inventory.is_app(args.app_name):
         logger.fatal('Can\'t {} {} - not found in the app inventory. Run {} --list-apps to print '
-                     'out the app inventory'.format(entry_point, args_parser.app_name, entry_point))
+                     'out the app inventory'.format(entry_point, args.app_name, entry_point))
         sys.exit(1)
     # Host
-    if not host_inventory.is_host(args_parser.host):
+    if not host_inventory.is_host(args.host):
         logger.fatal('{} is not a valid host - make sure it\'s defined in your inventory file - '
-                     'see Ansible documentation online'.format(args_parser.host))
+                     'see Ansible documentation online'.format(args.host))
         sys.exit(1)
 
     # ----------------------------------------------------------------------------------------------
     # Create an App instance
     #
-    app = app_inventory.get_app(args_parser.app_name)
+    app = app_inventory.get_app(args.app_name)
 
     # ----------------------------------------------------------------------------------------------
     # Deploy the app
     #
-    deployment = Deployment(app, args_parser.host, app.install_method)
+    deployment = Deployment(app, args.host, app.install_method)
     deployment.execute()
 
 

--- a/app_deployer/deploy_script.py
+++ b/app_deployer/deploy_script.py
@@ -8,7 +8,7 @@ import coloredlogs
 
 # Import modules from this app
 from app_deployer.logger import setup_logging
-from app_deployer.args import parse_args
+from app_deployer.args_parser import parse_args
 from app_deployer.deployment import DeploymentError, Deployment
 
 # Import variables from this app
@@ -27,7 +27,6 @@ def main(argv=None):
     # Setup logging
     logger = setup_logging(entry_point)
     # Parse command-line arguments
-    args = parse_args(argv[1:], entry_point)
     # Set log level
     logger.setLevel(getattr(logging, args.log_level))
     coloredlogs.install(fmt='%(message)s')
@@ -35,14 +34,14 @@ def main(argv=None):
     # ----------------------------------------------------------------------------------------------
     # Print out app inventory
     #
-    if args.list_apps:
+    if args_parser.list_apps:
         logger.info(app_inventory)
         sys.exit()
 
     # ----------------------------------------------------------------------------------------------
     # Print out hosts inventory
     #
-    if args.list_hosts:
+    if args_parser.list_hosts:
         logger.info(host_inventory)
         sys.exit()
 
@@ -59,25 +58,25 @@ def main(argv=None):
     # Validate the positional args
     #
     # App
-    if not app_inventory.is_app(args.app_name):
+    if not app_inventory.is_app(args_parser.app_name):
         logger.fatal('Can\'t {} {} - not found in the app inventory. Run {} --list-apps to print '
-                     'out the app inventory'.format(entry_point, args.app_name, entry_point))
+                     'out the app inventory'.format(entry_point, args_parser.app_name, entry_point))
         sys.exit(1)
     # Host
-    if not host_inventory.is_host(args.host):
+    if not host_inventory.is_host(args_parser.host):
         logger.fatal('{} is not a valid host - make sure it\'s defined in your inventory file - '
-                     'see Ansible documentation online'.format(args.host))
+                     'see Ansible documentation online'.format(args_parser.host))
         sys.exit(1)
 
     # ----------------------------------------------------------------------------------------------
     # Create an App instance
     #
-    app = app_inventory.get_app(args.app_name)
+    app = app_inventory.get_app(args_parser.app_name)
 
     # ----------------------------------------------------------------------------------------------
     # Deploy the app
     #
-    deployment = Deployment(app, args.host, app.install_method)
+    deployment = Deployment(app, args_parser.host, app.install_method)
     deployment.execute()
 
 

--- a/app_deployer/rollback_script.py
+++ b/app_deployer/rollback_script.py
@@ -4,6 +4,7 @@ import logging
 
 # Import third-party packages
 import appdirs
+import coloredlogs
 
 # Import modules from this app
 from app_deployer.logger import setup_logging
@@ -28,6 +29,7 @@ def main(argv=None):
     args = parse_args(argv[1:], entry_point)
     # Set log level
     logger.setLevel(getattr(logging, args.log_level))
+    coloredlogs.install(fmt='%(message)s')
 
     # ----------------------------------------------------------------------------------------------
     # Print out app inventory

--- a/app_deployer/rollback_script.py
+++ b/app_deployer/rollback_script.py
@@ -8,7 +8,7 @@ import coloredlogs
 
 # Import modules from this app
 from app_deployer.logger import setup_logging
-from app_deployer.args import parse_args
+from app_deployer.args_parser import parse_args
 
 # Import variables from this app
 from app_deployer import app_inventory, ansible_exe, host_inventory

--- a/app_deployer/rollback_script.py
+++ b/app_deployer/rollback_script.py
@@ -9,6 +9,7 @@ import coloredlogs
 # Import modules from this app
 from app_deployer.logger import setup_logging
 from app_deployer.args_parser import parse_args
+from app_deployer import args_parser
 
 # Import variables from this app
 from app_deployer import app_inventory, ansible_exe, host_inventory
@@ -26,7 +27,8 @@ def main(argv=None):
     # Setup logging
     logger = setup_logging(entry_point)
     # Parse command-line arguments
-    args = parse_args(argv[1:], entry_point)
+    args_parser.args = parse_args(argv[1:], entry_point)
+    args = args_parser.args
     # Set log level
     logger.setLevel(getattr(logging, args.log_level))
     coloredlogs.install(fmt='%(message)s')

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,10 @@ with open('CHANGELOG.md') as history_file:
 
 requirements = [
     'pyyaml',
-    'appdirs'
+    'appdirs',
+    'gitpython',
+    'coloredlogs',
+    'colorama',
 ]
 
 setup(


### PR DESCRIPTION
I want to save a globally-accessible variable called `args` to `args.py`. This may get confusing, so renaming `args.py` to `args_parser.py` should help.

For example, now every module can access the command line args that were parsed:

    from app_deployer import args_parser

    args = args_parser.args